### PR TITLE
Security: lock down credits, essays access, and AI feedback endpoints

### DIFF
--- a/src/app/api/ai-feedback/route.ts
+++ b/src/app/api/ai-feedback/route.ts
@@ -1,12 +1,55 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { AIService } from '../../../services/aiService';
 import { AiFeedbackRequest } from '../../../types/aiService';
+import { getAuthenticatedUser } from '../../../lib/api-auth';
+import { CreditService } from '../../../services/creditService';
+
+const MAX_ESSAY_LENGTH = 50_000; // chars; well above any real essay
 
 export async function POST(request: NextRequest) {
   try {
+    // Feedback costs OpenAI tokens and a user credit — require a verified
+    // user and consume the credit before generating.
+    const user = await getAuthenticatedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+
     const body: AiFeedbackRequest = await request.json();
-    const response = await AIService.processAIFeedbackRequest(body);
-    return NextResponse.json(response);
+
+    if (!body?.essay?.essay_content || body.essay.essay_content.length > MAX_ESSAY_LENGTH) {
+      return NextResponse.json(
+        { error: 'Essay content is missing or too long' },
+        { status: 400 }
+      );
+    }
+
+    const creditConsumed = await CreditService.consumeCredits(
+      user.id,
+      1,
+      'AI feedback request'
+    );
+    if (!creditConsumed) {
+      return NextResponse.json(
+        {
+          error: 'Insufficient credits',
+          message: 'You need at least 1 credit to get AI feedback. Please purchase more credits.',
+          requiresCredits: true
+        },
+        { status: 402 }
+      );
+    }
+
+    try {
+      const response = await AIService.processAIFeedbackRequest(body);
+      return NextResponse.json(response);
+    } catch (aiError) {
+      await CreditService.addCredits(user.id, 1); // refund
+      throw aiError;
+    }
 
   } catch (error) {
     console.error('Error processing AI feedback request:', error);

--- a/src/app/api/essays/route.ts
+++ b/src/app/api/essays/route.ts
@@ -1,11 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Essay } from '../../../types/essay';
 import { getAdminClient } from '../../../lib/supabase-admin-client';
+import { getAuthenticatedUser } from '../../../lib/api-auth';
 import { EmailService } from '../../../services/emailService';
 import { AIService } from '../../../services/aiService';
 import { AiFeedbackRequest } from '../../../types/aiService';
 import { CreditService } from '../../../services/creditService';
 import { EssayDuplicateDetectionService } from '../../../services/essayDuplicateDetectionService';
+
+const MAX_ESSAY_LENGTH = 50_000; // chars; well above any real essay
 
 interface EssaySubmissionRequest {
   essay: Essay;
@@ -19,29 +22,28 @@ interface EssaySubmissionRequest {
 
 export async function POST(request: NextRequest) {
   try {
+    // The user is derived from the verified token — never from the request
+    // body, which would let callers spend other users' credits (or nobody's).
+    const user = await getAuthenticatedUser(request);
+    if (!user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+    }
+    const userId = user.id;
+
     const body: EssaySubmissionRequest = await request.json();
 
     // Handle both legacy format (direct Essay) and new format (with essay property)
     const essay: Essay = 'essay' in body ? body.essay : body as Essay;
     const wordCount = body.word_count;
-    const userInfo = body.user_info;
 
-    // Get user ID from userInfo or try to extract from essay email
-    const userId = userInfo?.user_id;
-
-    // If we have word count (meaning AI feedback is requested) and user ID, check credits
-    if (wordCount && userId) {
-      const hasSufficientCredits = await CreditService.hasSufficientCredits(userId, 1);
-      if (!hasSufficientCredits) {
-        return NextResponse.json(
-          {
-            error: 'Insufficient credits',
-            message: 'You need at least 1 credit to get AI feedback. Please purchase more credits.',
-            requiresCredits: true
-          },
-          { status: 402 } // Payment Required
-        );
-      }
+    if (!essay?.essay_content || essay.essay_content.length > MAX_ESSAY_LENGTH) {
+      return NextResponse.json(
+        { error: 'Essay content is missing or too long' },
+        { status: 400 }
+      );
     }
 
     // Check for duplicate submissions (only for personal statements with AI feedback requested)
@@ -64,6 +66,27 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Consume the credit atomically before generating feedback; refunded
+    // below if generation fails. A post-generation consume would let two
+    // concurrent submissions get feedback for one credit.
+    if (wordCount) {
+      const creditConsumed = await CreditService.consumeCredits(
+        userId,
+        1,
+        'AI feedback for essay submission'
+      );
+      if (!creditConsumed) {
+        return NextResponse.json(
+          {
+            error: 'Insufficient credits',
+            message: 'You need at least 1 credit to get AI feedback. Please purchase more credits.',
+            requiresCredits: true
+          },
+          { status: 402 } // Payment Required
+        );
+      }
+    }
+
     const supabaseAdmin = await getAdminClient();
 
     const { data, error } = await supabaseAdmin
@@ -74,6 +97,7 @@ export async function POST(request: NextRequest) {
 
     if (error) {
       console.error('Error saving essay:', error.message);
+      if (wordCount) await CreditService.addCredits(userId, 1); // refund
       return NextResponse.json(
         { error: 'Failed to save essay', details: error.message },
         { status: 500 }
@@ -95,7 +119,7 @@ export async function POST(request: NextRequest) {
             created_at: data.created_at,
             word_count: wordCount,
           },
-          ...(userInfo && { user_info: userInfo })
+          user_info: { user_id: userId, email: user.email }
         };
 
         await AIService.processAIFeedbackRequest(aiFeedbackRequest).then(async (feedback) => {
@@ -106,20 +130,6 @@ export async function POST(request: NextRequest) {
 
           if (updateError) {
             throw updateError;
-          }
-
-          // Consume credits after successful AI feedback processing
-          if (userId) {
-            const creditConsumed = await CreditService.consumeCredits(
-              userId,
-              1,
-              `AI feedback for essay: ${data.id}`
-            );
-
-            if (!creditConsumed) {
-              console.error('Failed to consume credits for user:', userId);
-              // Note: We don't fail the request here since the feedback was already generated
-            }
           }
 
           // Send feedback email to student
@@ -140,6 +150,7 @@ export async function POST(request: NextRequest) {
         })
       } catch (aiError) {
         console.error('Error generating feedback:', aiError);
+        await CreditService.addCredits(userId, 1); // refund
         return NextResponse.json(
           { error: 'Failed to save essay', details: aiError },
           { status: 500 }

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -2,10 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import Stripe from 'stripe';
 import { CONFIG_KEYS, ConfigService } from '../../../../services/configService';
 import { supabase } from '../../../../lib/supabase';
+import { creditPackages } from '../../../../config/products';
 
 interface CheckoutRequest {
   priceId: string;
-  credits: number;
   successUrl?: string;
   cancelUrl?: string;
 }
@@ -42,11 +42,14 @@ export async function POST(request: NextRequest) {
     }
 
     const body: CheckoutRequest = await request.json();
-    const { priceId, credits, successUrl, cancelUrl } = body;
+    const { priceId, successUrl, cancelUrl } = body;
 
-    if (!priceId || !credits) {
+    // Credits come from the server-side package list keyed by price —
+    // a client-sent credit count must never reach the webhook.
+    const creditPackage = creditPackages.find(p => p.priceId === priceId);
+    if (!creditPackage) {
       return NextResponse.json(
-        { error: 'Price ID and credits amount are required' },
+        { error: 'Unknown price ID' },
         { status: 400 }
       );
     }
@@ -66,7 +69,7 @@ export async function POST(request: NextRequest) {
       allow_promotion_codes: true,
       metadata: {
         userId: user.id,
-        credits: credits.toString(),
+        priceId: creditPackage.priceId,
         email: user.email || '',
       },
     });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -3,6 +3,8 @@ import Stripe from 'stripe';
 import { CONFIG_KEYS, ConfigService } from '../../../../services/configService';
 import { CreditService } from '../../../../services/creditService';
 import { ReferralService } from '../../../../services/referralService';
+import { creditPackages } from '../../../../config/products';
+import { getAdminClient } from '../../../../lib/supabase-admin-client';
 
 export async function POST(request: NextRequest) {
   try {
@@ -49,15 +51,44 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ received: true });
     }
     const userId = session.metadata?.userId;
-    const credits = session.metadata?.credits;
-    if (!userId || !credits) {
-      console.log('[no user id] ', event.type);
+    const priceId = session.metadata?.priceId;
+    if (!userId || !priceId) {
+      console.log('[no user id / price id] ', event.type);
       return NextResponse.json({ received: true });
     }
-    await CreditService.addCredits(
-      userId,
-      +credits,
-    );
+
+    // Credits are derived from the server-side package list, never from
+    // metadata a client could have influenced.
+    const creditPackage = creditPackages.find(p => p.priceId === priceId);
+    if (!creditPackage) {
+      console.error('[unknown price id] ', priceId);
+      return NextResponse.json({ received: true });
+    }
+
+    // Idempotency: Stripe retries deliveries. Claim the event id first;
+    // a conflict means another delivery already processed (or is processing) it.
+    const supabaseAdmin = await getAdminClient();
+    const { data: claimed, error: claimError } = await supabaseAdmin
+      .from('stripe_events')
+      .insert({ id: event.id })
+      .select('id')
+      .maybeSingle();
+
+    if (claimError || !claimed) {
+      if (claimError && claimError.code !== '23505') {
+        console.error('[stripe_events] failed to record event:', claimError);
+        return NextResponse.json({ error: 'Failed to record event' }, { status: 500 });
+      }
+      console.log('[duplicate event] ', event.id);
+      return NextResponse.json({ received: true });
+    }
+
+    const granted = await CreditService.addCredits(userId, creditPackage.credits);
+    if (!granted) {
+      // Release the claim and let Stripe retry — the user paid.
+      await supabaseAdmin.from('stripe_events').delete().eq('id', event.id);
+      return NextResponse.json({ error: 'Failed to grant credits' }, { status: 500 });
+    }
 
     await ReferralService.rewardReferrer(userId);
 

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -1,0 +1,21 @@
+import 'server-only';
+import { NextRequest } from 'next/server';
+import { User } from '@supabase/supabase-js';
+import { getAdminClient } from './supabase-admin-client';
+
+/**
+ * Verifies the Bearer token on an API request and returns the Supabase user.
+ * Returns null when the header is missing or the token is invalid.
+ */
+export async function getAuthenticatedUser(request: NextRequest): Promise<User | null> {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader) return null;
+
+  const token = authHeader.replace('Bearer ', '');
+  const supabase = await getAdminClient();
+
+  const { data: { user }, error } = await supabase.auth.getUser(token);
+  if (error || !user) return null;
+
+  return user;
+}

--- a/src/lib/supabase-admin-client.ts
+++ b/src/lib/supabase-admin-client.ts
@@ -5,11 +5,9 @@ import { supabaseUrl } from '../config/supabase';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { cookies } from 'next/headers'
 
-// Access auth admin api
-let adminAuthClient: SupabaseClient<any, "public", any> | null = null;
-
-export async function getAdminClient() {
-  if (adminAuthClient) return adminAuthClient;
+// Built per request: caching a client would close over the first
+// request's cookie store and reuse it for every later request.
+export async function getAdminClient(): Promise<SupabaseClient<any, "public", any>> {
   const cookieStore = await cookies()
 
   const service_role_key = await ConfigService.getConfigValue(CONFIG_KEYS.DB_SERVICE_ROLE_KEY);
@@ -33,5 +31,5 @@ export async function getAdminClient() {
       },
     },
   })
-  return adminAuthClient = supabase;
+  return supabase;
 }

--- a/src/services/creditService.ts
+++ b/src/services/creditService.ts
@@ -47,42 +47,25 @@ export class CreditService {
     }
   }
 
-  // TODO: move to backend
+  // Atomic: single UPDATE guarded by `credits >= amount`, so concurrent
+  // requests can't double-spend. Returns false when credits are insufficient.
   static async consumeCredits(userId: string, amount: number = 1, description: string = 'Essay feedback'): Promise<boolean> {
     try {
       const supaAdmin = await getAdminClient();
+      const { data, error } = await supaAdmin
+        .rpc('consume_user_credits', { p_user_id: userId, p_amount: amount });
 
-      // First check if user has sufficient credits
-      const { data: userData, error: fetchError } = await supaAdmin
-        .from('users')
-        .select('credits')
-        .eq('id', userId)
-        .single();
-
-      if (fetchError) {
-        console.error('Error fetching user credits:', fetchError);
+      if (error) {
+        console.error('Error consuming credits:', error);
         return false;
       }
 
-      const currentCredits = userData?.credits || 0;
-      if (currentCredits < amount) {
-        console.error('Insufficient credits:', { currentCredits, required: amount });
-        return false;
-      }
-      console.log({ currentCredits, userData })
-
-      // Consume credits
-      const { error: updateError } = await supaAdmin
-        .from('users')
-        .update({ credits: currentCredits - amount })
-        .eq('id', userId);
-
-      if (updateError) {
-        console.error('Error consuming credits:', updateError);
+      if (data === null) {
+        console.error('Insufficient credits for user:', userId);
         return false;
       }
 
-      console.log(`Successfully consumed ${amount} credits for user ${userId}. Remaining: ${currentCredits - amount}`);
+      console.log(`Successfully consumed ${amount} credits for user ${userId}. Remaining: ${data}`);
       return true;
     } catch (error) {
       console.error('Error in consumeCredits:', error);
@@ -90,36 +73,18 @@ export class CreditService {
     }
   }
 
-  // TODO: move to backend
   static async addCredits(userId: string, amount: number): Promise<boolean> {
     try {
       const supabaseAdmin = await getAdminClient();
+      const { data, error } = await supabaseAdmin
+        .rpc('add_user_credits', { p_user_id: userId, p_amount: amount });
 
-      const { data: userData, error: fetchError } = await supabaseAdmin
-        .from('users')
-        .select('credits')
-        .eq('id', userId)
-        .single();
-
-      if (fetchError) {
-        console.error('[Error] fetching user credits:', fetchError);
+      if (error || data === null) {
+        console.error('[Error] adding credits:', error ?? 'user not found');
         return false;
       }
 
-      const currentCredits = userData?.credits || 0;
-      const newCredits = currentCredits + amount;
-
-      const { error: updateError } = await supabaseAdmin
-        .from('users')
-        .update({ credits: newCredits })
-        .eq('id', userId);
-
-      if (updateError) {
-        console.error('[Error] adding credits:', updateError);
-        return false;
-      }
-
-      console.log(`[Success] added ${amount} credits for user ${userId}. New balance: ${newCredits}`);
+      console.log(`[Success] added ${amount} credits for user ${userId}. New balance: ${data}`);
       return true;
     } catch (error) {
       console.error('Error in addCredits:', error);

--- a/src/services/essayService.ts
+++ b/src/services/essayService.ts
@@ -69,10 +69,17 @@ export const essayService = {
         ...(userInfo && { user_info: userInfo })
       };
 
+      // The API derives the user from this token; submissions require login.
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) {
+        throw new Error('You must be signed in to submit an essay');
+      }
+
       const response = await fetch('/api/essays', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${session.access_token}`,
         },
         body: JSON.stringify(requestBody),
       });

--- a/src/utils/aiFeedbackClient.ts
+++ b/src/utils/aiFeedbackClient.ts
@@ -1,5 +1,6 @@
 import { Essay } from '../types/essay';
 import { AiFeedbackRequest, AiFeedbackResponse } from '../types/aiService';
+import { supabase } from '../lib/supabase';
 
 // Legacy interface for backward compatibility
 interface LegacyAiFeedbackRequest {
@@ -38,10 +39,17 @@ export async function submitEssayForFeedback(
       ...(userInfo && { user_info: userInfo })
     };
 
+    // The API derives the user from this token and consumes a credit.
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      throw new Error('You must be signed in to request feedback');
+    }
+
     const response = await fetch('/api/ai-feedback', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'Authorization': `Bearer ${session.access_token}`,
       },
       body: JSON.stringify(requestBody),
     });

--- a/supabase/migrations/20260612000001_security_critical_fixes.sql
+++ b/supabase/migrations/20260612000001_security_critical_fixes.sql
@@ -1,0 +1,128 @@
+/*
+  # Security: critical fixes
+
+  1. Drop the anon read policy on config (exposed backend secrets to anyone
+     with the public anon key; code reads process.env now).
+  2. Block clients from updating users.credits / users.role directly.
+     The "Users can update own profile" RLS policy allows updating the whole
+     row, which let any user set their own credit balance (and role).
+  3. Enable RLS on essays with owner-scoped policies (table previously had
+     no RLS — any anon-key holder could read/delete every essay).
+  4. Atomic credit functions so balance changes are single-statement
+     (the old read-then-write pattern lost updates under concurrency).
+  5. stripe_events table for webhook idempotency (Stripe retries deliveries).
+*/
+
+-- 1. config: remove anon read access
+DROP POLICY IF EXISTS "Allow anonymous read access to config" ON config;
+
+-- 2. users: protect credits/role from client-side updates.
+-- SECURITY INVOKER (default) so current_user reflects the API role:
+-- PostgREST runs as anon/authenticated for client requests and as
+-- service_role for server requests; SQL editor/migrations run as postgres.
+CREATE OR REPLACE FUNCTION public.protect_users_sensitive_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF (to_jsonb(NEW) -> 'credits' IS DISTINCT FROM to_jsonb(OLD) -> 'credits'
+      OR to_jsonb(NEW) -> 'role' IS DISTINCT FROM to_jsonb(OLD) -> 'role')
+     AND current_user NOT IN ('postgres', 'supabase_admin', 'service_role') THEN
+    RAISE EXCEPTION 'credits and role can only be modified by the server';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS protect_users_sensitive_columns ON users;
+CREATE TRIGGER protect_users_sensitive_columns
+  BEFORE UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.protect_users_sensitive_columns();
+
+-- 3. essays: enable RLS, owner-scoped by student_email.
+-- Inserts and feedback updates go through server routes (service role,
+-- bypasses RLS), so clients only need SELECT and DELETE on their own rows.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'essays'
+  ) THEN
+    ALTER TABLE public.essays ENABLE ROW LEVEL SECURITY;
+
+    DROP POLICY IF EXISTS "Users can read own essays" ON public.essays;
+    DROP POLICY IF EXISTS "Users can delete own essays" ON public.essays;
+
+    CREATE POLICY "Users can read own essays"
+      ON public.essays
+      FOR SELECT
+      TO authenticated
+      USING (student_email = auth.email());
+
+    CREATE POLICY "Users can delete own essays"
+      ON public.essays
+      FOR DELETE
+      TO authenticated
+      USING (student_email = auth.email());
+  END IF;
+END $$;
+
+-- 4. Atomic credit mutations. SECURITY DEFINER so the sensitive-column
+-- trigger sees a privileged current_user; execution is revoked from
+-- client roles — only the service role (server) may call these.
+CREATE OR REPLACE FUNCTION public.consume_user_credits(p_user_id uuid, p_amount integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new_balance integer;
+BEGIN
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+
+  UPDATE public.users
+  SET credits = credits - p_amount
+  WHERE id = p_user_id AND credits >= p_amount
+  RETURNING credits INTO v_new_balance;
+
+  RETURN v_new_balance; -- NULL means insufficient credits (or no such user)
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.add_user_credits(p_user_id uuid, p_amount integer)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_new_balance integer;
+BEGIN
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'amount must be positive';
+  END IF;
+
+  UPDATE public.users
+  SET credits = credits + p_amount
+  WHERE id = p_user_id
+  RETURNING credits INTO v_new_balance;
+
+  RETURN v_new_balance; -- NULL means no such user
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.consume_user_credits(uuid, integer) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.add_user_credits(uuid, integer) FROM PUBLIC, anon, authenticated;
+
+-- 5. Webhook idempotency. RLS enabled with no policies: only the service
+-- role can touch it.
+CREATE TABLE IF NOT EXISTS public.stripe_events (
+  id text PRIMARY KEY,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.stripe_events ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260612000001_security_critical_fixes.sql
+++ b/supabase/migrations/20260612000001_security_critical_fixes.sql
@@ -13,8 +13,16 @@
   5. stripe_events table for webhook idempotency (Stripe retries deliveries).
 */
 
--- 1. config: remove anon read access
-DROP POLICY IF EXISTS "Allow anonymous read access to config" ON config;
+-- 1. config: remove anon read access (table may not exist in all envs)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'config'
+  ) THEN
+    DROP POLICY IF EXISTS "Allow anonymous read access to config" ON public.config;
+  END IF;
+END $$;
 
 -- 2. users: protect credits/role from client-side updates.
 -- SECURITY INVOKER (default) so current_user reflects the API role:


### PR DESCRIPTION
Fixes the six critical findings from a full code review.

## What anyone could do before this PR
- POST `/api/ai-feedback` with no auth → unlimited GPT-4.1 completions on our OpenAI bill
- POST `/api/essays` omitting `user_info.user_id` → AI feedback with no credit consumed; or pass another user's UUID → spend *their* credits
- Check out the cheapest Stripe package with `credits: 9999` in the body → webhook grants 9999 credits
- `UPDATE users SET credits = 999999` from the browser console (RLS self-update policy covered the whole row)
- Read/delete any student's essays (`essays` had no RLS in migrations)
- `SELECT * FROM config` as anon (table built to hold backend secrets)

## Changes
**Routes**
- `/api/essays`, `/api/ai-feedback`: require a verified Supabase Bearer token (same pattern as `/api/credits/balance`); user id taken from the token only; 50k-char essay cap; credit consumed atomically up front, refunded if generation fails
- `/api/stripe/checkout`: validates `priceId` against the server-side package list; stores `priceId` (not a credit count) in metadata
- `/api/stripe/webhook`: derives credits from the package list by `priceId`; idempotent via `stripe_events` claim row; returns 500 (Stripe retries) if the grant fails instead of silently dropping a paid order

**Migration** (`20260612000001_security_critical_fixes.sql`)
- Drops the anon read policy on `config`
- Trigger blocks client-role updates to `users.credits` / `users.role`
- Enables RLS on `essays` with owner-scoped (by `student_email`) SELECT/DELETE policies
- Atomic `consume_user_credits` / `add_user_credits` RPCs (single-statement, no read-modify-write race); execute revoked from client roles
- `stripe_events` table for webhook idempotency

**Client/lib**
- `essayService.saveEssay` + `aiFeedbackClient` attach the session token
- `getAdminClient` no longer caches the first request's cookie store
- `CreditService.consumeCredits`/`addCredits` use the new RPCs

## Deploy notes (order matters)
1. Apply the migration **before** deploying the app (routes call the new RPCs)
2. Verify in Supabase dashboard that `essays` RLS is actually enabled in prod (table was created out-of-band — it's not in migrations)
3. Confirm the `config` table holds no secrets; rotate anything that was ever in it
4. In-flight Stripe sessions created before deploy carry `credits` metadata, not `priceId` — the webhook will skip them; grant manually if one lands in the gap

## Not in this PR (next up, by severity)
- Stored XSS: feedback rendered via `marked` + `dangerouslySetInnerHTML` without sanitization (`src/app/essay/[id]/page.tsx:192`)
- Realtime subscription clobbers search/pagination in `useSchools`
- CSV formula injection in admin export

🤖 Generated with [Claude Code](https://claude.com/claude-code)